### PR TITLE
arch: Fix conanfile_rtc.py

### DIFF
--- a/conanfile_rtc.py
+++ b/conanfile_rtc.py
@@ -1,10 +1,10 @@
 from conans import ConanFile
 
 class SPIRVToolsConan(ConanFile):
-    name = "SPIRV-Tools"
+    name = "spirv-tools"
     version = "0.0.1"
-    url = "https://github.com/duncanthomson/SPIRV-Tools"
-    license = "https://github.com/duncanthomson/SPIRV-Tools/blob/main/LICENSE"
+    url = "https://github.com/Esri/SPIRV-Tools/blob/runtimecore"
+    license = "https://github.com/Esri/SPIRV-Tools/blob/runtimecore/LICENSE"
     description = "An API and commands for processing SPIR-V modules"
 
     # RTC specific triple


### PR DESCRIPTION
This PR:

- Fixes a mistake in the conan file. The casing of the `name` was wrong. It didn't match the casing of the static lib being build (conanfile: `SPIRV-Tools`; [static lib](https://github.com/Esri/SPIRV-Tools/blob/runtimecore/spirv-tools.lua#L1): `spirv-tools`). This meant that the static lib was not being packaged into the conan package, only the headers.
- Tidies up the URL and license.