### PR TITLE
arch: Add source/opt/*.h files to conan package

### DIFF
--- a/conanfile_rtc.py
+++ b/conanfile_rtc.py
@@ -17,6 +17,7 @@ class SPIRVToolsConan(ConanFile):
         # headers
         self.copy("*.h", src=base + "/include", dst=relative + "/include")
         self.copy("*.hpp", src=base + "/include", dst=relative + "/include")
+        self.copy("*.h", src=base + "/source/opt", dst=relative + "/source/opt")
 
         # libraries
         output = "output/" + str(self.settings.platform_architecture_target) + "/staticlib"


### PR DESCRIPTION
Dawn expects to #include these "internal" header files. [This 3rdparty vTest run](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1163/downstreambuildview/) shows what happens if we build dawn against the currently packaged spirv-tools headers. E.g. search for `source/opt/` in [this console log](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-android/1099/console)