### PR TITLE
Add files to conanfile

### DIFF
--- a/conanfile_rtc.py
+++ b/conanfile_rtc.py
@@ -18,6 +18,8 @@ class SPIRVToolsConan(ConanFile):
         self.copy("*.h", src=base + "/include", dst=relative + "/include")
         self.copy("*.hpp", src=base + "/include", dst=relative + "/include")
         self.copy("*.h", src=base + "/source", dst=relative + "/source")
+        self.copy("*.h", src=base + "/out/gen", dst=relative + "/out/gen")
+        self.copy("*.inc", src=base + "/out/gen", dst=relative + "/out/gen")
 
         # libraries
         output = "output/" + str(self.settings.platform_architecture_target) + "/staticlib"


### PR DESCRIPTION
This PR adds the generated files to `conanfile_rtc.py`. This is because if the Dawn repo is cloned without also cloning SPIRV-Tools, it fails to build. The same happens to vTests that build a custom branch of Dawn without SPIRV-Tools. 